### PR TITLE
feat: 일기 엔티티 구성 / 리포지토리 생성

### DIFF
--- a/src/main/java/org/fire/domain/Article.java
+++ b/src/main/java/org/fire/domain/Article.java
@@ -1,0 +1,38 @@
+package org.fire.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_no", updatable = false)
+    private Long articleNo; // 기본키
+
+    @Column(name = "title", nullable = false)
+    private String title; // 일기 제목
+
+    @Column(name = "content", nullable = false)
+    private String content; // 일기 내용
+
+    @Column(name = "author", nullable = false)
+    private String author; // 일기 작성자
+
+    @Column(name = "date", nullable = false)
+    private String date; // 일기 작성 날짜
+
+    @Builder
+    public Article(String title, String content, String author, String date) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.date = date;
+    }
+}

--- a/src/main/java/org/fire/repository/YourtoodayRepository.java
+++ b/src/main/java/org/fire/repository/YourtoodayRepository.java
@@ -1,0 +1,7 @@
+package org.fire.repository;
+
+import org.fire.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface YourtoodayRepository extends JpaRepository<Article, Long> {
+}


### PR DESCRIPTION
일기 작성에 필요한 항목을 가진 클래스인 Article을 엔티티로 지정하였습니다.
JpaRepository를 상속받는 엔티티 Article과 엔티티의 PK 타입 Long을 인수로 가지는 YourtoodayRepository 인터페이스를 생성하였습니다.